### PR TITLE
Some fixes and allowing * for all instances

### DIFF
--- a/Command/CommandFactory.cs
+++ b/Command/CommandFactory.cs
@@ -312,7 +312,7 @@ namespace sensu_client.Command
                                 normalizeString(counter.CategoryName),
                                 normalizeString(counter.CounterName.Replace('.', '_').Replace("%", "_PERCENT_")).Replace("_PERCENT_", "percent."),
                                 "performance_counter");
-                    schema = Regex.Replace(schema, @"_*\._*", @"\.");
+                    schema = Regex.Replace(schema, @"_*\._*", @".");
                     try
                     {
                         var value = counter.NextValue();

--- a/Program.cs
+++ b/Program.cs
@@ -41,9 +41,7 @@ namespace sensu_client
             }
             catch (Exception exception)
             {
-                _log.Error("Error in startup sensu-client",exception);
-                _log.Error(exception);
-                
+                _log.Error("Error in startup sensu-client: {0}", exception);
             }
             
         }

--- a/README.md
+++ b/README.md
@@ -122,4 +122,35 @@ This feature will return the information in a format Graphite-compatible, and wi
 schema value unix_timestamp
 ```
 
+Arguments for `!perfcounter>` command are:
 
+- `warn`: the limit for warnings.
+- `critical`: the limmit for errors.
+- `growth`: can be `asc` (the default), if should alert with values over the limits or `desc` if should alert with values below the limits.
+- `schema`: the stats name. Should be Graphite-compliant.
+
+The `schema` admits different variables, such as:
+- `{INSTANCE}`, which will be replaced by the Performance Counter instance name.
+- `{COUNTER}`, which will be replaced by the Performance Counter name.
+- `{CATEGORY}`, which will be replaced by the Performance Counter category.
+
+They will be normalized in order to avoid names with non-letters or numbers.
+
+Finally, you can use the asterisk `*` to configure **any** instance:
+
+```
+{
+  "checks": {
+    "Windows_CPU": {
+      "command": "!perfcounter> processor(*)\\% processor time; warn=80; critical=90; schema=processor.{INSTANCE}.time",
+      "type": "standard",
+      "standalone": true,
+      "handlers": [
+        "default"
+      ],
+    }
+  }
+}
+```
+
+In this case, it will fail if **any** processor passes the limits.


### PR DESCRIPTION
Some fixes (one of them made the sensu-server to crash).
Adding "*" for to refer all instances for a performance counter
Adding variables for schema names.
Allowing alerting in decreasing counters (like Free Space)

Not too proud of this code, but this is one of my firsts steps in c# and I'm in a hurry...
