### PR TITLE
Fix version, issued and mail_to arguments

### DIFF
--- a/CheckProcessor.cs
+++ b/CheckProcessor.cs
@@ -169,7 +169,10 @@ namespace sensu_client
             var payload = new JObject();
             payload["check"] = check;
             payload["client"] = _sensuClientConfigurationReader.SensuClientConfig.Client.Name;
+            if (_sensuClientConfigurationReader.SensuClientConfig.Client.MailTo.Count > 0)
+                payload["check"]["mail_to"] = string.Join(",", _sensuClientConfigurationReader.SensuClientConfig.Client.MailTo);
             payload["check"]["executed"] = SensuClientHelper.CreateTimeStamp();
+            payload["check"]["issued"] = payload["check"]["executed"];
 
             try
             {

--- a/Configuration/SensuClientConfig.cs
+++ b/Configuration/SensuClientConfig.cs
@@ -35,6 +35,8 @@ namespace sensu_client.Configuration
             get { return _send_metric_with_check; }
             set { _send_metric_with_check = value; }
         }
+        [JsonProperty("mail_to")]
+        public List<string> MailTo { get; set; }
     }
 
     public class Rabbitmq

--- a/KeepAliveScheduler.cs
+++ b/KeepAliveScheduler.cs
@@ -10,6 +10,7 @@ using RabbitMQ.Client.Framing.v0_9_1;
 using sensu_client.Configuration;
 using sensu_client.Connection;
 using sensu_client.Helpers;
+using System.Reflection;
 
 namespace sensu_client
 {
@@ -21,6 +22,7 @@ namespace sensu_client
         private static readonly Logger Log = LogManager.GetCurrentClassLogger();
         private static readonly object MonitorObject = new object();
         private readonly ManualResetEvent _stopEvent = new ManualResetEvent(false);
+        private static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version + "-C#";
 
         public KeepAliveScheduler(ISensuRabbitMqConnectionFactory connectionFactory, ISensuClientConfigurationReader sensuClientConfigurationReader)
         {
@@ -104,6 +106,7 @@ namespace sensu_client
             var keepAlive = _sensuClientConfigurationReader.Configuration.Config["client"];
 
             keepAlive["timestamp"] = SensuClientHelper.CreateTimeStamp();
+            keepAlive["version"] = Version; // Undocumented stuff to send the client version
             keepAlive["plugins"] = "";
 
             List<string> redactlist = null;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.1.5.1")]
 [assembly: AssemblyFileVersion("0.1.5.0")]

--- a/sensu-client.csproj
+++ b/sensu-client.csproj
@@ -25,9 +25,8 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <ApplicationRevision>35</ApplicationRevision>
+    <ApplicationVersion>1.5.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>


### PR DESCRIPTION
Three headers more to be sent:
- issued: This fixes an incompatibility with mailer handler.
- mail_to: mailer handler again: allows to override the list of mail receivers.
- version: shows the correct version in the Uchiwa dashboard (undocumented)
